### PR TITLE
Hstojic/trigger docs

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -27,4 +27,4 @@ jobs:
           curl -X POST https://api.github.com/repos/Bellman-devs/Bellman-devs.github.io/dispatches \
           -H 'Accept: application/vnd.github.v3+json' \
           -u ${{ secrets.ACCESS_TOKEN }} \
-          --data '{"event_type": "PushOnDevelopBranch", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'", "tag": "0.1.0" }}'
+          --data '{"event_type": "PushOnDevelopBranch", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'", "tag": "'"$GITHUB_REF"'" }}'

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -27,4 +27,4 @@ jobs:
           curl -X POST https://api.github.com/repos/Bellman-devs/Bellman-devs.github.io/dispatches \
           -H 'Accept: application/vnd.github.v3+json' \
           -u ${{ secrets.ACCESS_TOKEN }} \
-          --data '{"event_type": "PushOnDevelopBranch", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'", "tag": "'"$GITHUB_REF"'" }}'
+          --data '{"event_type": "PushOnDevelopBranch", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'", "tag": "'"$GITHUB_REF"'", "version": "0.1.0" }}'

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -27,4 +27,4 @@ jobs:
           curl -X POST https://api.github.com/repos/Bellman-devs/Bellman-devs.github.io/dispatches \
           -H 'Accept: application/vnd.github.v3+json' \
           -u ${{ secrets.ACCESS_TOKEN }} \
-          --data '{"event_type": "PushOnDevelopBranch", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'" }}'
+          --data '{"event_type": "PushOnDevelopBranch", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'", "tag": "0.1.0" }}'

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,21 +1,30 @@
+# Copyright 2021 The Bellman Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 on:
   push:
     branches:
       - develop
+      - hstojic/trigger_docs
 
 jobs:
-  docs:
+  trigger-docs-generation:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-    - run: |
-        TMPDIR=$(mktemp)
-        wget -O $TMPDIR https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-1-amd64.deb
-        sudo dpkg -i $TMPDIR
-        pip install poetry
-        poetry install
-        pip install -r docs/docs_requirements.txt
-        poetry run task docsgen
+      - name: Send dispatch to website repo
+        run: |
+          curl -X POST https://api.github.com/repos/Bellman-devs/Bellman-devs.github.io/dispatches \
+          -H 'Accept: application/vnd.github.v3+json' \
+          -u ${{ secrets.ACCESS_TOKEN }} \
+          --data '{"event_type": "PushOnDevelopBranch", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'" }}'

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -16,7 +16,6 @@ on:
   push:
     branches:
       - develop
-      - hstojic/trigger_docs
 
 jobs:
   trigger-docs-generation:
@@ -27,4 +26,4 @@ jobs:
           curl -X POST https://api.github.com/repos/Bellman-devs/Bellman-devs.github.io/dispatches \
           -H 'Accept: application/vnd.github.v3+json' \
           -u ${{ secrets.ACCESS_TOKEN }} \
-          --data '{"event_type": "PushOnDevelopBranch", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'", "tag": "'"$GITHUB_REF"'", "version": "0.1.0" }}'
+          --data '{"event_type": "PushOnDevelopBranch", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'", "tag": "'"$GITHUB_REF"'"}}'


### PR DESCRIPTION
modified a github action to trigger generating documentation in the website repo instead
action sends an event that an action in website repo is listening to
tested and it seems to work, check https://belman.dev/docs

see: 
- https://docs.github.com/en/actions/reference/events-that-trigger-workflows#external-events-repository_dispatch
- https://docs.github.com/en/rest/reference/repos#create-a-repository-dispatch-event
- https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#repository_dispatch