### PR TITLE
John/fix none loss in harness

### DIFF
--- a/bellman/training/schedule.py
+++ b/bellman/training/schedule.py
@@ -118,6 +118,7 @@ class TFTrainingScheduler:
             if step_counter >= training_definition.interval:
                 step_counter.assign(0)
                 loss_info = training_definition.train_step()
-                training_info[component] = loss_info
+                if loss_info.loss is not None:
+                    training_info[component] = loss_info
 
         return training_info

--- a/tests/unit/bellman/training/test_schedule.py
+++ b/tests/unit/bellman/training/test_schedule.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import tensorflow as tf
+from tf_agents.agents.tf_agent import LossInfo
 
 from bellman.training.schedule import TFTrainingScheduler, TrainingDefinition
 from tests.tools.bellman.training.schedule import (
@@ -149,3 +150,14 @@ def test_training_scheduler_resets_one_step_counter_of_several():
         loss_dictionary_3[MultiComponentAgent.COMPONENT_3].extra
         == MultiComponentAgent.COMPONENT_3.name
     )
+
+
+def test_training_info_does_not_contain_none_losses():
+    def _none_returning_train_step():
+        return LossInfo(loss=None, extra=None)
+
+    schedule = {SingleComponentAgent.COMPONENT: TrainingDefinition(1, _none_returning_train_step)}
+    training_scheduler = TFTrainingScheduler(schedule)
+
+    loss_dictionary = training_scheduler.maybe_train(tf.ones(tuple(), dtype=tf.int64))
+    assert not loss_dictionary  # loss_dictionary should be empty

--- a/tests/unit/bellman/training/test_schedule.py
+++ b/tests/unit/bellman/training/test_schedule.py
@@ -156,7 +156,9 @@ def test_training_info_does_not_contain_none_losses():
     def _none_returning_train_step():
         return LossInfo(loss=None, extra=None)
 
-    schedule = {SingleComponentAgent.COMPONENT: TrainingDefinition(1, _none_returning_train_step)}
+    schedule = {
+        SingleComponentAgent.COMPONENT: TrainingDefinition(1, _none_returning_train_step)
+    }
     training_scheduler = TFTrainingScheduler(schedule)
 
     loss_dictionary = training_scheduler.maybe_train(tf.ones(tuple(), dtype=tf.int64))


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you do not need to edit/remove them) -->

<!-- Thank you very much for spending time on contributing to Bellman!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->


**PR type:** bugfix 

**Related issue(s)/PRs: N/A


## Summary

**Proposed changes**
There is an integration issue between the `TFTrainingScheduler` and the `ExperimentHarness` where if the call to the agent trainer's `train_step` method returns `None` for the loss, the harness throws an exception when trying to write the logs. This situation can occur when insufficiently many environment steps have passed to train a model-free agent component of a model-based agent.

This PR addresses the issue by intercepting the `None` loss from the agent trainer in the scheduler and not adding it to the `training_info` dictionary.


### Minimal working example

The `run_mbpo` example hits this problem on the first environment time step.


## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [x] The bug case / new feature is covered by unit tests
- [x] Code has type annotations
- [x] I ran the black+isort formatter
- [x] I locally tested that the tests pass


### Release notes

<!-- leave blank if unsure -->

**Fully backwards compatible:** yes 

**If not, why is it worth breaking backwards compatibility:**
<!-- include a short justification -->


**Commit message (for release notes):**

* ...
